### PR TITLE
Fix bugs in Range class

### DIFF
--- a/include/Mathema.h
+++ b/include/Mathema.h
@@ -325,9 +325,9 @@ namespace RLLib
         ranges.clear();
       }
 
-      Ranges(const Range<T>& that)
+      Ranges(const Ranges<T>& that)
       {
-        for (typename Vectors<T>::iterator iter = that.begin(); iter != that.end(); ++iter)
+        for (typename Ranges<T>::iterator iter = that.begin(); iter != that.end(); ++iter)
           ranges.push_back(*iter);
       }
 
@@ -336,7 +336,7 @@ namespace RLLib
         if (this != that)
         {
           ranges.clear();
-          for (typename Vectors<T>::iterator iter = that.begin(); iter != that.end(); ++iter)
+          for (typename Ranges<T>::iterator iter = that.begin(); iter != that.end(); ++iter)
             ranges.push_back(*iter);
         }
         return *this;


### PR DESCRIPTION
This fixes what I believe to be 3 small bugs in the Range class. I have not tested this yet but the compiler complained about these so I went and analyzed the problems. I actually am still in the process of getting familiar with your code-base so this may all be wrong, but I am fairly convinced these changes make sense.

To start with, the class Range does not provide begin() and end() methods, so the change on line 328 should be correct.
Also, the for loops both start by calling the begin() method on a Ranges object, so I believe the type of iterator should be Ranges::iterator rather than a Vectors::iterator.

By the way, I am trying to create a Python interface to your library, using SWIG. I am not sure how horrible my code is on a scale 1:10, so I will put it on GitHub when horribleness is < 4.
